### PR TITLE
add clause for error stat

### DIFF
--- a/src/prometheus_diameter_collector.erl
+++ b/src/prometheus_diameter_collector.erl
@@ -132,9 +132,9 @@ gather_statistics(SvcName, Peer, S, Apps, Stats) ->
 			      {type, msg_type(Msg)},
 			      {msg, msg_name(Msg, Apps)},
 			      {rc, RC}]], Cnt, S1);
-	 ({{Msg, _Direction, error}, Cnt}, S1) ->
+	 ({{_, _, error}, Cnt}, S1) ->
               add([errors,[{svc, SvcName}, {peer, Peer},
-                           {error, Msg}]], Cnt, S1);
+                           {error, unknown}]], Cnt, S1);
 	 ({{Msg, Direction, Result}, Cnt}, S1) when is_atom(Result) ->
 	      add([messages, [{svc, SvcName}, {peer, Peer},
 			      {direction, Direction},

--- a/src/prometheus_diameter_collector.erl
+++ b/src/prometheus_diameter_collector.erl
@@ -132,6 +132,9 @@ gather_statistics(SvcName, Peer, S, Apps, Stats) ->
 			      {type, msg_type(Msg)},
 			      {msg, msg_name(Msg, Apps)},
 			      {rc, RC}]], Cnt, S1);
+	 ({{Msg, _Direction, error}, Cnt}, S1) ->
+              add([errors,[{svc, SvcName}, {peer, Peer},
+                           {error, Msg}]], Cnt, S1);
 	 ({{Msg, Direction, Result}, Cnt}, S1) when is_atom(Result) ->
 	      add([messages, [{svc, SvcName}, {peer, Peer},
 			      {direction, Direction},


### PR DESCRIPTION
`gather_statistics` can encounter error terms like `{{unknown,send,error},1}`.
Add a clause to handle them.